### PR TITLE
Adding support for parsing timeout

### DIFF
--- a/src/de/tuebingen/rparse/parser/RCGParser.java
+++ b/src/de/tuebingen/rparse/parser/RCGParser.java
@@ -26,6 +26,7 @@ package de.tuebingen.rparse.parser;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.concurrent.TimeoutException;
 
 import de.tuebingen.rparse.treebank.ProcessingTask;
 import de.tuebingen.rparse.treebank.TreebankException;
@@ -50,6 +51,11 @@ public interface RCGParser {
      * @return true if there is a parse
      */
     public boolean parse(ParserInput parserInput);
+
+    /**
+     * Parse a sentence within a number of seconds
+     */
+    public boolean parseWithTimeout(ParserInput parserInput, int seconds) throws TimeoutException;
 
     /**
      * Reset the parser after parsing a sentence.


### PR DESCRIPTION
I added one new method to the RCGParser interface: parseWithTimeout(), and a small timeout check in each iteration of the parser loops. I don't think it will affect performance notably.

Also a new command line option -timeout
